### PR TITLE
Fix sensor reinitialization memory leak

### DIFF
--- a/Adafruit_LSM303_Accel.cpp
+++ b/Adafruit_LSM303_Accel.cpp
@@ -68,7 +68,7 @@ Adafruit_LSM303_Accel_Unified::Adafruit_LSM303_Accel_Unified(int32_t sensorID) {
  */
 bool Adafruit_LSM303_Accel_Unified::begin(uint8_t i2c_address, TwoWire *wire) {
 
-  if(i2c_dev) 
+  if (i2c_dev) 
     delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(i2c_address, wire);
 

--- a/Adafruit_LSM303_Accel.cpp
+++ b/Adafruit_LSM303_Accel.cpp
@@ -68,7 +68,7 @@ Adafruit_LSM303_Accel_Unified::Adafruit_LSM303_Accel_Unified(int32_t sensorID) {
  */
 bool Adafruit_LSM303_Accel_Unified::begin(uint8_t i2c_address, TwoWire *wire) {
 
-  if (i2c_dev) 
+  if (i2c_dev)
     delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(i2c_address, wire);
 

--- a/Adafruit_LSM303_Accel.cpp
+++ b/Adafruit_LSM303_Accel.cpp
@@ -68,6 +68,7 @@ Adafruit_LSM303_Accel_Unified::Adafruit_LSM303_Accel_Unified(int32_t sensorID) {
  */
 bool Adafruit_LSM303_Accel_Unified::begin(uint8_t i2c_address, TwoWire *wire) {
 
+  if(i2c_dev) delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(i2c_address, wire);
 
   if (!i2c_dev->begin()) {

--- a/Adafruit_LSM303_Accel.cpp
+++ b/Adafruit_LSM303_Accel.cpp
@@ -68,7 +68,8 @@ Adafruit_LSM303_Accel_Unified::Adafruit_LSM303_Accel_Unified(int32_t sensorID) {
  */
 bool Adafruit_LSM303_Accel_Unified::begin(uint8_t i2c_address, TwoWire *wire) {
 
-  if(i2c_dev) delete i2c_dev;
+  if(i2c_dev) 
+    delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(i2c_address, wire);
 
   if (!i2c_dev->begin()) {


### PR DESCRIPTION
Hi folks,

This minor pull request begins to address the memory leaks the LSM303AGR suffers from during power down/power up cycling. Described in more detail in https://github.com/adafruit/Adafruit_LSM303_Accel/issues/9. 

Similar to https://github.com/adafruit/Adafruit_LSM6DS/pull/29, this PR checks for and deletes new objects created during initialization, in this case`i2c_dev`. I have confirmed that this change prevents the memory leak when repeatedly reinitializing the LSM303AGR.

A similar memory leak issue is also present in the LSM303AGR Mag library, which I'll look to resolve next.

Cheers,
Adam