### PR TITLE
Initialize i2c_dev to nullptr in header file

### DIFF
--- a/Adafruit_LSM303_Accel.cpp
+++ b/Adafruit_LSM303_Accel.cpp
@@ -75,17 +75,17 @@ bool Adafruit_LSM303_Accel_Unified::begin(uint8_t i2c_address, TwoWire *wire) {
   if (!i2c_dev->begin()) {
     return false;
   }
-  Adafruit_BusIO_Register ctrl1 =
-      Adafruit_BusIO_Register(i2c_dev, LSM303_REGISTER_ACCEL_CTRL_REG1_A, 1);
-  // Enable the accelerometer (100Hz)
-  ctrl1.write(0x57);
-
   Adafruit_BusIO_Register chip_id =
       Adafruit_BusIO_Register(i2c_dev, LSM303_REGISTER_ACCEL_WHO_AM_I, 1);
   if (chip_id.read() != 0x33) {
     // No LSM30 detected ... return false
     return false;
   }
+
+  Adafruit_BusIO_Register ctrl1 =
+      Adafruit_BusIO_Register(i2c_dev, LSM303_REGISTER_ACCEL_CTRL_REG1_A, 1);
+  // Enable the accelerometer (100Hz)
+  ctrl1.write(0x57);
 
   return true;
 }

--- a/Adafruit_LSM303_Accel.h
+++ b/Adafruit_LSM303_Accel.h
@@ -120,7 +120,7 @@ private:
 
   void readRawData(void);
 
-  Adafruit_I2CDevice *i2c_dev;
+  Adafruit_I2CDevice *i2c_dev = nullptr;
 };
 
 #endif

--- a/Adafruit_LSM303_Accel.h
+++ b/Adafruit_LSM303_Accel.h
@@ -120,7 +120,7 @@ private:
 
   void readRawData(void);
 
-  Adafruit_I2CDevice *i2c_dev = nullptr;
+  Adafruit_I2CDevice *i2c_dev = NULL;
 };
 
 #endif

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit LSM303 Accel
-version=1.1.8
+version=1.1.9
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Unified Accelerometer sensor driver for Adafruit's LSM303 Breakout


### PR DESCRIPTION
As part of testing in WipperSnapper offline mode, there was instability on the pico checking the i2c_dev was empty at init.